### PR TITLE
checkpolicy,libsepol: add prefix/suffix matching to filename type transitions

### DIFF
--- a/checkpolicy/policy_define.c
+++ b/checkpolicy/policy_define.c
@@ -3211,7 +3211,7 @@ avrule_t *define_cond_filename_trans(void)
 	return COND_ERR;
 }
 
-int define_filename_trans(void)
+int define_filename_trans(uint32_t match_type)
 {
 	char *id, *name = NULL;
 	type_set_t stypes, ttypes;
@@ -3313,7 +3313,7 @@ int define_filename_trans(void)
 			ebitmap_for_each_positive_bit(&e_ttypes, tnode, t) {
 				rc = policydb_filetrans_insert(
 					policydbp, s+1, t+1, c+1, name,
-					NULL, otype, NULL
+					NULL, otype, match_type, NULL
 				);
 				if (rc != SEPOL_OK) {
 					if (rc == SEPOL_EEXIST) {
@@ -3331,7 +3331,7 @@ int define_filename_trans(void)
 			if (self) {
 				rc = policydb_filetrans_insert(
 					policydbp, s+1, s+1, c+1, name,
-					NULL, otype, NULL
+					NULL, otype, match_type, NULL
 				);
 				if (rc != SEPOL_OK) {
 					if (rc == SEPOL_EEXIST) {
@@ -3369,6 +3369,7 @@ int define_filename_trans(void)
 		ftr->tclass = c + 1;
 		ftr->otype = otype;
 		ftr->flags = self ? RULE_SELF : 0;
+		ftr->match_type = match_type;
 	}
 
 	free(name);

--- a/checkpolicy/policy_define.h
+++ b/checkpolicy/policy_define.h
@@ -57,7 +57,7 @@ int define_role_trans(int class_specified);
 int define_role_types(void);
 int define_role_attr(void);
 int define_roleattribute(void);
-int define_filename_trans(void);
+int define_filename_trans(uint32_t match_type);
 int define_sens(void);
 int define_te_avtab(int which);
 int define_te_avtab_extended_perms(int which);

--- a/checkpolicy/policy_parse.y
+++ b/checkpolicy/policy_parse.y
@@ -154,6 +154,7 @@ typedef int (* require_func_t)(int pass);
 %token DEFAULT_USER DEFAULT_ROLE DEFAULT_TYPE DEFAULT_RANGE
 %token LOW_HIGH LOW HIGH GLBLUB
 %token INVALID_CHAR
+%token PREFIX SUFFIX
 
 %left OR
 %left XOR
@@ -413,6 +414,12 @@ cond_rule_def           : cond_transition_def
 cond_transition_def	: TYPE_TRANSITION names names ':' names identifier filename ';'
                         { $$ = define_cond_filename_trans() ;
                           if ($$ == COND_ERR) YYABORT;}
+			| TYPE_TRANSITION names names ':' names identifier filename PREFIX ';'
+                        { $$ = define_cond_filename_trans() ;
+                          if ($$ == COND_ERR) YYABORT;}
+			| TYPE_TRANSITION names names ':' names identifier filename SUFFIX ';'
+                        { $$ = define_cond_filename_trans() ;
+                          if ($$ == COND_ERR) YYABORT;}
 			| TYPE_TRANSITION names names ':' names identifier ';'
                         { $$ = define_cond_compute_type(AVRULE_TRANSITION) ;
                           if ($$ == COND_ERR) YYABORT;}
@@ -450,7 +457,11 @@ cond_dontaudit_def	: DONTAUDIT names names ':' names names ';'
 		        ;
 			;
 transition_def		: TYPE_TRANSITION  names names ':' names identifier filename ';'
-			{if (define_filename_trans()) YYABORT; }
+			{if (define_filename_trans(FILENAME_TRANS_MATCH_EXACT)) YYABORT; }
+			| TYPE_TRANSITION  names names ':' names identifier filename PREFIX ';'
+			{if (define_filename_trans(FILENAME_TRANS_MATCH_PREFIX)) YYABORT; }
+			| TYPE_TRANSITION  names names ':' names identifier filename SUFFIX ';'
+			{if (define_filename_trans(FILENAME_TRANS_MATCH_SUFFIX)) YYABORT; }
 			| TYPE_TRANSITION names names ':' names identifier ';'
                         {if (define_compute_type(AVRULE_TRANSITION)) YYABORT;}
                         | TYPE_MEMBER names names ':' names identifier ';'

--- a/checkpolicy/policy_scan.l
+++ b/checkpolicy/policy_scan.l
@@ -286,6 +286,10 @@ low |
 LOW				{ return(LOW); }
 glblub |
 GLBLUB				{ return(GLBLUB); }
+PREFIX |
+prefix				{ return(PREFIX); }
+SUFFIX |
+suffix				{ return(SUFFIX); }
 "/"[^ \n\r\t\f]*	        { return(PATH); }
 \""/"[^\"\n]*\" 		{ return(QPATH); }
 \"[^"/"\"\n]+\"	{ return(FILENAME); }

--- a/checkpolicy/test/dismod.c
+++ b/checkpolicy/test/dismod.c
@@ -570,13 +570,25 @@ static void display_role_allow(role_allow_rule_t * ra, policydb_t * p, FILE * fp
 
 static void display_filename_trans(filename_trans_rule_t * tr, policydb_t * p, FILE * fp)
 {
+	const char *match_str = "";
 	fprintf(fp, "filename transition");
 	for (; tr; tr = tr->next) {
 		display_type_set(&tr->stypes, 0, p, fp);
 		display_type_set(&tr->ttypes, 0, p, fp);
 		display_id(p, fp, SYM_CLASSES, tr->tclass - 1, ":");
 		display_id(p, fp, SYM_TYPES, tr->otype - 1, "");
-		fprintf(fp, " %s\n", tr->name);
+		switch (tr->match_type) {
+		case FILENAME_TRANS_MATCH_EXACT:
+			match_str = "";
+			break;
+		case FILENAME_TRANS_MATCH_PREFIX:
+			match_str = " prefix";
+			break;
+		case FILENAME_TRANS_MATCH_SUFFIX:
+			match_str = " suffix";
+			break;
+		}
+		fprintf(fp, " %s%s\n", tr->name, match_str);
 	}
 }
 

--- a/checkpolicy/test/dispol.c
+++ b/checkpolicy/test/dispol.c
@@ -460,6 +460,7 @@ static void display_role_trans(policydb_t *p, FILE *fp)
 
 struct filenametr_display_args {
 	policydb_t *p;
+	const char *match_str;
 	FILE *fp;
 };
 
@@ -474,6 +475,7 @@ static int filenametr_display(hashtab_key_t key,
 	FILE *fp = args->fp;
 	ebitmap_node_t *node;
 	uint32_t bit;
+	const char *match_str = args->match_str;
 
 	do {
 		ebitmap_for_each_positive_bit(&ftdatum->stypes, node, bit) {
@@ -481,7 +483,7 @@ static int filenametr_display(hashtab_key_t key,
 			display_id(p, fp, SYM_TYPES, ft->ttype - 1, "");
 			display_id(p, fp, SYM_CLASSES, ft->tclass - 1, ":");
 			display_id(p, fp, SYM_TYPES, ftdatum->otype - 1, "");
-			fprintf(fp, " %s\n", ft->name);
+			fprintf(fp, " %s%s\n", ft->name, match_str);
 		}
 		ftdatum = ftdatum->next;
 	} while (ftdatum);
@@ -497,7 +499,15 @@ static void display_filename_trans(policydb_t *p, FILE *fp)
 	fprintf(fp, "filename_trans rules:\n");
 	args.p = p;
 	args.fp = fp;
-	hashtab_map(p->filename_trans, filenametr_display, &args);
+	args.match_str = "";
+	hashtab_map(p->filename_trans[FILENAME_TRANS_MATCH_EXACT],
+		    filenametr_display, &args);
+	args.match_str = " prefix";
+	hashtab_map(p->filename_trans[FILENAME_TRANS_MATCH_PREFIX],
+		    filenametr_display, &args);
+	args.match_str = " suffix";
+	hashtab_map(p->filename_trans[FILENAME_TRANS_MATCH_SUFFIX],
+		    filenametr_display, &args);
 }
 
 static int menu(void)

--- a/checkpolicy/tests/policy_allonce.conf
+++ b/checkpolicy/tests/policy_allonce.conf
@@ -30,6 +30,8 @@ tunable TUNABLE1 false;
 tunable TUNABLE2 true;
 type_transition TYPE1 TYPE2 : CLASS1 TYPE3;
 type_transition { TYPE1 TYPE2 } { TYPE3 TYPE4 } : CLASS1 TYPE1 "FILENAME";
+type_transition { TYPE1 TYPE2 } { TYPE3 TYPE4 } : CLASS1 TYPE1 "FILENAME" prefix;
+type_transition { TYPE1 TYPE2 } { TYPE3 TYPE4 } : CLASS1 TYPE1 "FILENAME" suffix;
 type_member TYPE1 TYPE2 : CLASS1 TYPE2;
 type_change TYPE1 TYPE2 : CLASS1 TYPE3;
 allow TYPE1 self : CLASS1 { PERM1 };

--- a/checkpolicy/tests/policy_allonce.expected.conf
+++ b/checkpolicy/tests/policy_allonce.expected.conf
@@ -40,9 +40,17 @@ dontauditxperm TYPE1 TYPE2:CLASS1 ioctl { 0x3 };
 type_transition TYPE1 TYPE2:CLASS1 TYPE3;
 type_member TYPE1 TYPE2:CLASS1 TYPE2;
 type_change TYPE1 TYPE2:CLASS1 TYPE3;
+type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME";
 if (BOOL1) {
 } else {

--- a/checkpolicy/tests/policy_allonce.expected_opt.conf
+++ b/checkpolicy/tests/policy_allonce.expected_opt.conf
@@ -40,9 +40,17 @@ dontauditxperm TYPE1 TYPE2:CLASS1 ioctl { 0x3 };
 type_transition TYPE1 TYPE2:CLASS1 TYPE3;
 type_member TYPE1 TYPE2:CLASS1 TYPE2;
 type_change TYPE1 TYPE2:CLASS1 TYPE3;
+type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME";
 if (BOOL1) {
 } else {

--- a/checkpolicy/tests/policy_allonce_mls.conf
+++ b/checkpolicy/tests/policy_allonce_mls.conf
@@ -41,6 +41,8 @@ tunable TUNABLE1 false;
 tunable TUNABLE2 true;
 type_transition TYPE1 TYPE2 : CLASS1 TYPE3;
 type_transition { TYPE1 TYPE2 } { TYPE3 TYPE4 } : CLASS1 TYPE1 "FILENAME";
+type_transition { TYPE1 TYPE2 } { TYPE3 TYPE4 } : CLASS1 TYPE1 "FILENAME" prefix;
+type_transition { TYPE1 TYPE2 } { TYPE3 TYPE4 } : CLASS1 TYPE1 "FILENAME" suffix;
 type_member TYPE1 TYPE2 : CLASS1 TYPE2;
 type_change TYPE1 TYPE2 : CLASS1 TYPE3;
 range_transition TYPE1 TYPE2 : CLASS1 s1:c0.c1;

--- a/checkpolicy/tests/policy_allonce_mls.expected.conf
+++ b/checkpolicy/tests/policy_allonce_mls.expected.conf
@@ -51,9 +51,17 @@ dontauditxperm TYPE1 TYPE2:CLASS1 ioctl { 0x3 };
 type_transition TYPE1 TYPE2:CLASS1 TYPE3;
 type_member TYPE1 TYPE2:CLASS1 TYPE2;
 type_change TYPE1 TYPE2:CLASS1 TYPE3;
+type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME";
 range_transition TYPE1 TYPE2:CLASS1 s1:c0,c1 - s1:c0,c1;
 if (BOOL1) {

--- a/checkpolicy/tests/policy_allonce_mls.expected_opt.conf
+++ b/checkpolicy/tests/policy_allonce_mls.expected_opt.conf
@@ -51,9 +51,17 @@ dontauditxperm TYPE1 TYPE2:CLASS1 ioctl { 0x3 };
 type_transition TYPE1 TYPE2:CLASS1 TYPE3;
 type_member TYPE1 TYPE2:CLASS1 TYPE2;
 type_change TYPE1 TYPE2:CLASS1 TYPE3;
+type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE1 TYPE3:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE1 TYPE4:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE2 TYPE3:CLASS1 TYPE1 "FILENAME";
+type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME" prefix;
+type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME" suffix;
 type_transition TYPE2 TYPE4:CLASS1 TYPE1 "FILENAME";
 range_transition TYPE1 TYPE2:CLASS1 s1:c0,c1 - s1:c0,c1;
 if (BOOL1) {

--- a/libsepol/cil/src/cil.c
+++ b/libsepol/cil/src/cil.c
@@ -97,6 +97,8 @@ char *CIL_KEY_TUNABLEIF;
 char *CIL_KEY_ALLOW;
 char *CIL_KEY_DONTAUDIT;
 char *CIL_KEY_TYPETRANSITION;
+char *CIL_KEY_PREFIX;
+char *CIL_KEY_SUFFIX;
 char *CIL_KEY_TYPECHANGE;
 char *CIL_KEY_CALL;
 char *CIL_KEY_TUNABLE;
@@ -269,6 +271,8 @@ static void cil_init_keys(void)
 	CIL_KEY_ALLOW = cil_strpool_add("allow");
 	CIL_KEY_DONTAUDIT = cil_strpool_add("dontaudit");
 	CIL_KEY_TYPETRANSITION = cil_strpool_add("typetransition");
+	CIL_KEY_PREFIX = cil_strpool_add("prefix");
+	CIL_KEY_SUFFIX = cil_strpool_add("suffix");
 	CIL_KEY_TYPECHANGE = cil_strpool_add("typechange");
 	CIL_KEY_CALL = cil_strpool_add("call");
 	CIL_KEY_TUNABLE = cil_strpool_add("tunable");
@@ -2461,6 +2465,7 @@ void cil_nametypetransition_init(struct cil_nametypetransition **nametypetrans)
 	(*nametypetrans)->obj = NULL;
 	(*nametypetrans)->name_str = NULL;
 	(*nametypetrans)->name = NULL;
+	(*nametypetrans)->match_type = FILENAME_TRANS_MATCH_EXACT;
 	(*nametypetrans)->result_str = NULL;
 	(*nametypetrans)->result = NULL;
 }

--- a/libsepol/cil/src/cil_binary.c
+++ b/libsepol/cil/src/cil_binary.c
@@ -1167,7 +1167,7 @@ static int __cil_typetransition_to_avtab_helper(policydb_t *pdb,
 						type_datum_t *sepol_src,
 						type_datum_t *sepol_tgt,
 						struct cil_list *class_list,
-						char *name,
+						char *name, uint32_t match_type,
 						type_datum_t *sepol_result)
 {
 	int rc;
@@ -1182,7 +1182,7 @@ static int __cil_typetransition_to_avtab_helper(policydb_t *pdb,
 		rc = policydb_filetrans_insert(
 			pdb, sepol_src->s.value, sepol_tgt->s.value,
 			sepol_obj->s.value, name, NULL,
-			sepol_result->s.value, &otype
+			sepol_result->s.value, match_type, &otype
 		);
 		if (rc != SEPOL_OK) {
 			if (rc == SEPOL_EEXIST) {
@@ -1251,7 +1251,7 @@ static int __cil_typetransition_to_avtab(policydb_t *pdb, const struct cil_db *d
 
 			rc = __cil_typetransition_to_avtab_helper(
 				pdb, sepol_src, sepol_src, class_list,
-				name, sepol_result
+				name, typetrans->match_type, sepol_result
 			);
 			if (rc != SEPOL_OK) goto exit;
 		}
@@ -1269,7 +1269,7 @@ static int __cil_typetransition_to_avtab(policydb_t *pdb, const struct cil_db *d
 
 				rc = __cil_typetransition_to_avtab_helper(
 					pdb, sepol_src, sepol_tgt, class_list,
-					name, sepol_result
+					name, typetrans->match_type, sepol_result
 				);
 				if (rc != SEPOL_OK) goto exit;
 			}

--- a/libsepol/cil/src/cil_copy_ast.c
+++ b/libsepol/cil/src/cil_copy_ast.c
@@ -723,6 +723,7 @@ int cil_copy_nametypetransition(__attribute__((unused)) struct cil_db *db, void 
 	new->obj_str = orig->obj_str;
 	new->name_str = orig->name_str;
 	new->name = orig->name;
+	new->match_type = orig->match_type;
 	new->result_str = orig->result_str;
 
 

--- a/libsepol/cil/src/cil_internal.h
+++ b/libsepol/cil/src/cil_internal.h
@@ -114,6 +114,8 @@ extern char *CIL_KEY_TUNABLEIF;
 extern char *CIL_KEY_ALLOW;
 extern char *CIL_KEY_DONTAUDIT;
 extern char *CIL_KEY_TYPETRANSITION;
+extern char *CIL_KEY_PREFIX;
+extern char *CIL_KEY_SUFFIX;
 extern char *CIL_KEY_TYPECHANGE;
 extern char *CIL_KEY_CALL;
 extern char *CIL_KEY_TUNABLE;
@@ -588,6 +590,7 @@ struct cil_nametypetransition {
 	struct cil_class *obj;
 	char *name_str;
 	struct cil_symtab_datum *name;
+	uint32_t match_type;
 	char *result_str;
 	void *result; /* type or alias */
 

--- a/libsepol/cil/src/cil_policy.c
+++ b/libsepol/cil/src/cil_policy.c
@@ -1259,15 +1259,30 @@ static void cil_nametypetransition_to_policy(FILE *out, struct cil_nametypetrans
 	struct cil_symtab_datum *src, *tgt, *name, *res;
 	struct cil_list *class_list;
 	struct cil_list_item *i1;
+	const char *match_type_str = "";
 
 	src = trans->src;
 	tgt = trans->tgt;
 	name = trans->name;
 	res = trans->result;
+	switch (trans->match_type) {
+	case FILENAME_TRANS_MATCH_EXACT:
+		match_type_str = "";
+		break;
+	case FILENAME_TRANS_MATCH_PREFIX:
+		match_type_str = " prefix";
+		break;
+	case FILENAME_TRANS_MATCH_SUFFIX:
+		match_type_str = " suffix";
+		break;
+	default:
+		match_type_str = " ???";
+		break;
+	}
 
 	class_list = cil_expand_class(trans->obj);
 	cil_list_for_each(i1, class_list) {
-		fprintf(out, "type_transition %s %s : %s %s \"%s\";\n", src->fqn, tgt->fqn, DATUM(i1->data)->fqn, res->fqn, name->fqn);
+		fprintf(out, "type_transition %s %s : %s %s \"%s\"%s;\n", src->fqn, tgt->fqn, DATUM(i1->data)->fqn, res->fqn, name->fqn, match_type_str);
 	}
 	cil_list_destroy(&class_list, CIL_FALSE);
 }

--- a/libsepol/cil/src/cil_write_ast.c
+++ b/libsepol/cil/src/cil_write_ast.c
@@ -1217,6 +1217,16 @@ void cil_write_ast_node(FILE *out, struct cil_tree_node *node)
 		} else {
 			fprintf(out, "%s ", rule->name_str);
 		}
+		switch (rule->match_type) {
+		case FILENAME_TRANS_MATCH_EXACT:
+			break;
+		case FILENAME_TRANS_MATCH_PREFIX:
+			fprintf(out, "prefix ");
+			break;
+		case FILENAME_TRANS_MATCH_SUFFIX:
+			fprintf(out, "suffix ");
+			break;
+		}
 		fprintf(out, "%s", datum_or_str(DATUM(rule->result), rule->result_str));
 		fprintf(out, ")\n");
 		break;

--- a/libsepol/include/sepol/policydb/policydb.h
+++ b/libsepol/include/sepol/policydb/policydb.h
@@ -321,6 +321,8 @@ typedef struct filename_trans_rule {
 	uint32_t tclass;
 	char *name;
 	uint32_t otype;	/* new type */
+ 	/* name match type, values from enum filename_trans_match_type */
+	uint32_t match_type;
 	struct filename_trans_rule *next;
 } filename_trans_rule_t;
 
@@ -422,6 +424,14 @@ typedef struct genfs {
 
 /* OCON_NUM needs to be the largest index in any platform's ocontext array */
 #define OCON_NUM   9
+
+/* filename transitions table array indices */
+enum filename_trans_match_type {
+	FILENAME_TRANS_MATCH_EXACT,
+	FILENAME_TRANS_MATCH_PREFIX,
+	FILENAME_TRANS_MATCH_SUFFIX,
+	FILENAME_TRANS_MATCH_NUM,
+};
 
 /* section: module information */
 
@@ -593,8 +603,8 @@ typedef struct policydb {
 	hashtab_t range_tr;
 
 	/* file transitions with the last path component */
-	hashtab_t filename_trans;
-	uint32_t filename_trans_count;
+	hashtab_t filename_trans[FILENAME_TRANS_MATCH_NUM];
+	uint32_t filename_trans_exact_count;
 
 	ebitmap_t *type_attr_map;
 
@@ -657,7 +667,8 @@ extern int policydb_sort_ocontexts(policydb_t *p);
 extern int policydb_filetrans_insert(policydb_t *p, uint32_t stype,
 				     uint32_t ttype, uint32_t tclass,
 				     const char *name, char **name_alloc,
-				     uint32_t otype, uint32_t *present_otype);
+				     uint32_t otype, uint32_t match_type,
+				     uint32_t *present_otype);
 
 /* Deprecated */
 extern int policydb_context_isvalid(const policydb_t * p,
@@ -758,10 +769,11 @@ extern int policydb_set_target_platform(policydb_t *p, int platform);
 #define POLICYDB_VERSION_INFINIBAND		31 /* Linux-specific */
 #define POLICYDB_VERSION_GLBLUB		32
 #define POLICYDB_VERSION_COMP_FTRANS	33 /* compressed filename transitions */
+#define POLICYDB_VERSION_PREFIX_SUFFIX	34 /* prefix and suffix filename transitions */
 
 /* Range of policy versions we understand*/
 #define POLICYDB_VERSION_MIN	POLICYDB_VERSION_BASE
-#define POLICYDB_VERSION_MAX	POLICYDB_VERSION_COMP_FTRANS
+#define POLICYDB_VERSION_MAX	POLICYDB_VERSION_PREFIX_SUFFIX
 
 /* Module versions and specific changes*/
 #define MOD_POLICYDB_VERSION_BASE		4
@@ -784,9 +796,10 @@ extern int policydb_set_target_platform(policydb_t *p, int platform);
 #define MOD_POLICYDB_VERSION_INFINIBAND		19
 #define MOD_POLICYDB_VERSION_GLBLUB		20
 #define MOD_POLICYDB_VERSION_SELF_TYPETRANS	21
+#define MOD_POLICYDB_VERSION_PREFIX_SUFFIX	22
 
 #define MOD_POLICYDB_VERSION_MIN MOD_POLICYDB_VERSION_BASE
-#define MOD_POLICYDB_VERSION_MAX MOD_POLICYDB_VERSION_SELF_TYPETRANS
+#define MOD_POLICYDB_VERSION_MAX MOD_POLICYDB_VERSION_PREFIX_SUFFIX
 
 #define POLICYDB_CONFIG_MLS    1
 

--- a/libsepol/src/expand.c
+++ b/libsepol/src/expand.c
@@ -1419,18 +1419,31 @@ static int expand_filename_trans_helper(expand_state_t *state,
 	rc = policydb_filetrans_insert(
 		state->out, s + 1, t + 1,
 		rule->tclass, rule->name,
-		NULL, mapped_otype, &present_otype
+		NULL, mapped_otype, rule->match_type, &present_otype
 	);
 	if (rc == SEPOL_EEXIST) {
 		/* duplicate rule, ignore */
 		if (present_otype == mapped_otype)
 			return 0;
 
-		ERR(state->handle, "Conflicting name-based type_transition %s %s:%s \"%s\":  %s vs %s",
+		const char *match_str = "";
+		switch (rule->match_type) {
+		case FILENAME_TRANS_MATCH_EXACT:
+			match_str = "";
+			break;
+		case FILENAME_TRANS_MATCH_PREFIX:
+			match_str = " prefix";
+			break;
+		case FILENAME_TRANS_MATCH_SUFFIX:
+			match_str = " suffix";
+			break;
+		}
+		ERR(state->handle, "Conflicting name-based type_transition %s %s:%s \"%s\"%s:  %s vs %s",
 		    state->out->p_type_val_to_name[s],
 		    state->out->p_type_val_to_name[t],
 		    state->out->p_class_val_to_name[rule->tclass - 1],
 		    rule->name,
+		    match_str,
 		    state->out->p_type_val_to_name[present_otype - 1],
 		    state->out->p_type_val_to_name[mapped_otype - 1]);
 		return -1;

--- a/libsepol/src/kernel_to_cil.c
+++ b/libsepol/src/kernel_to_cil.c
@@ -1899,6 +1899,7 @@ exit:
 
 struct map_filename_trans_args {
 	struct policydb *pdb;
+	const char *match_str;
 	struct strs *strs;
 };
 
@@ -1913,6 +1914,7 @@ static int map_filename_trans_to_str(hashtab_key_t key, void *data, void *arg)
 	struct ebitmap_node *node;
 	uint32_t bit;
 	int rc;
+	const char *match_str = map_args->match_str;
 
 	tgt = pdb->p_type_val_to_name[ft->ttype - 1];
 	class = pdb->p_class_val_to_name[ft->tclass - 1];
@@ -1923,8 +1925,8 @@ static int map_filename_trans_to_str(hashtab_key_t key, void *data, void *arg)
 		ebitmap_for_each_positive_bit(&datum->stypes, node, bit) {
 			src = pdb->p_type_val_to_name[bit];
 			rc = strs_create_and_add(strs,
-						 "(typetransition %s %s %s \"%s\" %s)",
-						 src, tgt, class, filename, new);
+						 "(typetransition %s %s %s \"%s\"%s %s)",
+						 src, tgt, class, filename, match_str, new);
 			if (rc)
 				return rc;
 		}
@@ -1949,7 +1951,23 @@ static int write_filename_trans_rules_to_cil(FILE *out, struct policydb *pdb)
 	args.pdb = pdb;
 	args.strs = strs;
 
-	rc = hashtab_map(pdb->filename_trans, map_filename_trans_to_str, &args);
+	args.match_str = "";
+	rc = hashtab_map(pdb->filename_trans[FILENAME_TRANS_MATCH_EXACT],
+			 map_filename_trans_to_str, &args);
+	if (rc != 0) {
+		goto exit;
+	}
+
+	args.match_str = " prefix";
+	rc = hashtab_map(pdb->filename_trans[FILENAME_TRANS_MATCH_PREFIX],
+			 map_filename_trans_to_str, &args);
+	if (rc != 0) {
+		goto exit;
+	}
+
+	args.match_str = " suffix";
+	rc = hashtab_map(pdb->filename_trans[FILENAME_TRANS_MATCH_SUFFIX],
+			 map_filename_trans_to_str, &args);
 	if (rc != 0) {
 		goto exit;
 	}

--- a/libsepol/src/kernel_to_conf.c
+++ b/libsepol/src/kernel_to_conf.c
@@ -1864,6 +1864,7 @@ exit:
 
 struct map_filename_trans_args {
 	struct policydb *pdb;
+	const char *match_str;
 	struct strs *strs;
 };
 
@@ -1878,6 +1879,7 @@ static int map_filename_trans_to_str(hashtab_key_t key, void *data, void *arg)
 	struct ebitmap_node *node;
 	uint32_t bit;
 	int rc;
+	const char *match_str = map_args->match_str;
 
 	tgt = pdb->p_type_val_to_name[ft->ttype - 1];
 	class = pdb->p_class_val_to_name[ft->tclass - 1];
@@ -1888,8 +1890,8 @@ static int map_filename_trans_to_str(hashtab_key_t key, void *data, void *arg)
 		ebitmap_for_each_positive_bit(&datum->stypes, node, bit) {
 			src = pdb->p_type_val_to_name[bit];
 			rc = strs_create_and_add(strs,
-						 "type_transition %s %s:%s %s \"%s\";",
-						 src, tgt, class, new, filename);
+						 "type_transition %s %s:%s %s \"%s\"%s;",
+						 src, tgt, class, new, filename, match_str);
 			if (rc)
 				return rc;
 		}
@@ -1914,7 +1916,23 @@ static int write_filename_trans_rules_to_conf(FILE *out, struct policydb *pdb)
 	args.pdb = pdb;
 	args.strs = strs;
 
-	rc = hashtab_map(pdb->filename_trans, map_filename_trans_to_str, &args);
+	args.match_str = "";
+	rc = hashtab_map(pdb->filename_trans[FILENAME_TRANS_MATCH_EXACT],
+			 map_filename_trans_to_str, &args);
+	if (rc != 0) {
+		goto exit;
+	}
+
+	args.match_str = " prefix";
+	rc = hashtab_map(pdb->filename_trans[FILENAME_TRANS_MATCH_PREFIX],
+			 map_filename_trans_to_str, &args);
+	if (rc != 0) {
+		goto exit;
+	}
+
+	args.match_str = " suffix";
+	rc = hashtab_map(pdb->filename_trans[FILENAME_TRANS_MATCH_SUFFIX],
+			 map_filename_trans_to_str, &args);
 	if (rc != 0) {
 		goto exit;
 	}

--- a/libsepol/src/link.c
+++ b/libsepol/src/link.c
@@ -1440,6 +1440,7 @@ static int copy_filename_trans_list(filename_trans_rule_t * list,
 		new_rule->name = strdup(cur->name);
 		if (!new_rule->name)
 			goto err;
+		new_rule->match_type = cur->match_type;
 
 		if (type_set_or_convert(&cur->stypes, &new_rule->stypes, module) ||
 		    type_set_or_convert(&cur->ttypes, &new_rule->ttypes, module))

--- a/libsepol/src/module_to_cil.c
+++ b/libsepol/src/module_to_cil.c
@@ -1618,6 +1618,7 @@ static int filename_trans_to_cil(int indent, struct policydb *pdb, struct filena
 	unsigned int ttype;
 	struct type_set *ts;
 	struct filename_trans_rule *rule;
+	const char *match_str = "";
 
 	for (rule = rules; rule != NULL; rule = rule->next) {
 		ts = &rule->stypes;
@@ -1632,19 +1633,31 @@ static int filename_trans_to_cil(int indent, struct policydb *pdb, struct filena
 			goto exit;
 		}
 
+		switch (rule->match_type) {
+		case FILENAME_TRANS_MATCH_EXACT:
+			match_str = "";
+			break;
+		case FILENAME_TRANS_MATCH_PREFIX:
+			match_str = " prefix";
+			break;
+		case FILENAME_TRANS_MATCH_SUFFIX:
+			match_str = " suffix";
+			break;
+		}
+
 		for (stype = 0; stype < num_stypes; stype++) {
 			for (ttype = 0; ttype < num_ttypes; ttype++) {
-				cil_println(indent, "(typetransition %s %s %s \"%s\" %s)",
+				cil_println(indent, "(typetransition %s %s %s \"%s\"%s %s)",
 					    stypes[stype], ttypes[ttype],
 					    pdb->p_class_val_to_name[rule->tclass - 1],
-					    rule->name,
+					    rule->name, match_str,
 					    pdb->p_type_val_to_name[rule->otype - 1]);
 			}
 			if (rule->flags & RULE_SELF) {
-				cil_println(indent, "(typetransition %s self %s \"%s\" %s)",
+				cil_println(indent, "(typetransition %s self %s \"%s\"%s %s)",
 					    stypes[stype],
 					    pdb->p_class_val_to_name[rule->tclass - 1],
-					    rule->name,
+					    rule->name, match_str,
 					    pdb->p_type_val_to_name[rule->otype - 1]);
 			}
 		}

--- a/libsepol/src/write.c
+++ b/libsepol/src/write.c
@@ -653,7 +653,8 @@ static int filename_write_one(hashtab_key_t key, void *data, void *ptr)
 	return 0;
 }
 
-static int filename_trans_write(struct policydb *p, void *fp)
+static int filename_trans_write(struct policydb *p, uint32_t match_type,
+				void *fp)
 {
 	size_t items;
 	uint32_t buf[1];
@@ -663,20 +664,25 @@ static int filename_trans_write(struct policydb *p, void *fp)
 		return 0;
 
 	if (p->policyvers < POLICYDB_VERSION_COMP_FTRANS) {
-		buf[0] = cpu_to_le32(p->filename_trans_count);
+		/*
+		 * This version does not have other than exact match
+		 * transitions, there is no need to count other ones.
+		 */
+		buf[0] = cpu_to_le32(p->filename_trans_exact_count);
 		items = put_entry(buf, sizeof(uint32_t), 1, fp);
 		if (items != 1)
 			return POLICYDB_ERROR;
 
-		rc = hashtab_map(p->filename_trans, filename_write_one_compat,
-				 fp);
+		rc = hashtab_map(p->filename_trans[match_type],
+				 filename_write_one_compat, fp);
 	} else {
-		buf[0] = cpu_to_le32(p->filename_trans->nel);
+		buf[0] = cpu_to_le32(p->filename_trans[match_type]->nel);
 		items = put_entry(buf, sizeof(uint32_t), 1, fp);
 		if (items != 1)
 			return POLICYDB_ERROR;
 
-		rc = hashtab_map(p->filename_trans, filename_write_one, fp);
+		rc = hashtab_map(p->filename_trans[match_type],
+				 filename_write_one, fp);
 	}
 	return rc;
 }
@@ -1944,11 +1950,25 @@ static int filename_trans_rule_write(policydb_t *p, filename_trans_rule_t *t,
 {
 	int nel = 0;
 	size_t items, entries;
-	uint32_t buf[3], len;
+	uint32_t buf[4], len;
 	filename_trans_rule_t *ftr;
+	int discarding = 0;
 
-	for (ftr = t; ftr; ftr = ftr->next)
-		nel++;
+	if (p->policyvers >= MOD_POLICYDB_VERSION_PREFIX_SUFFIX) {
+		for (ftr = t; ftr; ftr = ftr->next)
+			nel++;
+	} else {
+		for (ftr = t; ftr; ftr = ftr->next) {
+			if (ftr->match_type == FILENAME_TRANS_MATCH_EXACT)
+				nel++;
+			else
+				discarding = 1;
+		}
+		if (discarding) {
+			WARN(fp->handle,
+			     "Discarding prefix/suffix filename type transition rules");
+		}
+	}
 
 	buf[0] = cpu_to_le32(nel);
 	items = put_entry(buf, sizeof(uint32_t), 1, fp);
@@ -1956,6 +1976,9 @@ static int filename_trans_rule_write(policydb_t *p, filename_trans_rule_t *t,
 		return POLICYDB_ERROR;
 
 	for (ftr = t; ftr; ftr = ftr->next) {
+		if (p->policyvers < MOD_POLICYDB_VERSION_PREFIX_SUFFIX &&
+		    ftr->match_type != FILENAME_TRANS_MATCH_EXACT)
+			continue;
 		len = strlen(ftr->name);
 		buf[0] = cpu_to_le32(len);
 		items = put_entry(buf, sizeof(uint32_t), 1, fp);
@@ -1974,8 +1997,11 @@ static int filename_trans_rule_write(policydb_t *p, filename_trans_rule_t *t,
 		buf[0] = cpu_to_le32(ftr->tclass);
 		buf[1] = cpu_to_le32(ftr->otype);
 		buf[2] = cpu_to_le32(ftr->flags);
+		buf[3] = cpu_to_le32(ftr->match_type);
 
-		if (p->policyvers >= MOD_POLICYDB_VERSION_SELF_TYPETRANS) {
+		if (p->policyvers >= MOD_POLICYDB_VERSION_PREFIX_SUFFIX) {
+			entries = 4;
+		} else if (p->policyvers >= MOD_POLICYDB_VERSION_SELF_TYPETRANS) {
 			entries = 3;
 		} else if (!(ftr->flags & RULE_SELF)) {
 			entries = 2;
@@ -2370,11 +2396,28 @@ int policydb_write(policydb_t * p, struct policy_file *fp)
 		if (role_allow_write(p->role_allow, fp))
 			return POLICYDB_ERROR;
 		if (p->policyvers >= POLICYDB_VERSION_FILENAME_TRANS) {
-			if (filename_trans_write(p, fp))
+			if (filename_trans_write(p, FILENAME_TRANS_MATCH_EXACT,
+						 fp))
 				return POLICYDB_ERROR;
 		} else {
-			if (p->filename_trans)
+			if (p->filename_trans[FILENAME_TRANS_MATCH_EXACT])
 				WARN(fp->handle, "Discarding filename type transition rules");
+		}
+		if (p->policyvers >= POLICYDB_VERSION_PREFIX_SUFFIX) {
+			if (filename_trans_write(p, FILENAME_TRANS_MATCH_PREFIX,
+						 fp) ||
+			    filename_trans_write(p, FILENAME_TRANS_MATCH_SUFFIX,
+						 fp))
+				return POLICYDB_ERROR;
+		} else {
+			if (p->filename_trans[FILENAME_TRANS_MATCH_PREFIX] &&
+			    p->filename_trans[FILENAME_TRANS_MATCH_PREFIX]->nel)
+				WARN(fp->handle,
+				     "Discarding prefix filename type transition rules");
+			if (p->filename_trans[FILENAME_TRANS_MATCH_SUFFIX] &&
+			    p->filename_trans[FILENAME_TRANS_MATCH_SUFFIX]->nel)
+				WARN(fp->handle,
+				     "Discarding suffix filename type transition rules");
 		}
 	} else {
 		if (avrule_block_write(p->global, num_syms, p, fp) == -1) {

--- a/secilc/test/policy.cil
+++ b/secilc/test/policy.cil
@@ -134,6 +134,8 @@
 	(typetransition device_t exec_type files console_device_t)
 	(typetransition exec_type self files console_device_t)
 	(typetransition exec_type self files "filename" console_device_t)
+	(typetransition exec_type self files "filename" prefix console_device_t)
+	(typetransition exec_type self files "filename" suffix console_device_t)
 	(typechange console_device_t device_t file user_tty_device_t)
 	(typechange exec_type device_t file user_tty_device_t)
 	(typechange exec_type self file console_device_t)
@@ -153,6 +155,8 @@
 	(rangetransition device_t kernel_t file ((s0) (s3 (not c3))))
 
 	(typetransition device_t console_t file "some_file" getty_t)
+	(typetransition device_t console_t file "some_file" prefix getty_t)
+	(typetransition device_t console_t file "some_file" suffix getty_t)
 	
 	(allow foo_type self (file (execute)))
 	(allow bin_t device_t (file (execute)))


### PR DESCRIPTION
Currently, filename transitions are stored separately from other type enforcement rules and only support exact name matching. However, in practice, the names contain variable parts. This leads to many duplicated rules in the policy that differ only in the part of the name, or it is even impossible to cover all possible combinations.

This patch implements the equivalent changes made by this kernel patch [1].

This patch updates the policydb structure to contain prefix and suffix filename transition tables along normal filename transitions table and updates the code that accesses those tables. Furthermore, it adds match_type attribute to module and CIL structures that store filename transitions and updates functions that parse conf and CIL policy files.

This patch does not significantly change the binary policy size when prefix/suffix rules are not used. On the other hand, with prefix/suffix rules, the number of filename transitions can be reduced, and therefore also binary policy size can be reduced.

Syntax of the new prefix/suffix filename transition rule:

    type_transition source_type target_type : class default_type object_name match_type;

    (typetransition source_type_id target_type_id class_id object_name match_type default_type_id)

where match_type is either keyword "prefix" or "suffix"

Examples:

    type_transition ta tb:CLASS01 tc "file01" prefix;
    type_transition td te:CLASS01 tf "file02" suffix;

    (typetransition ta tb CLASS01 "file01" prefix td)
    (typetransition td te CLASS01 "file02" suffix tf)

[1]: TODO: PASTE LINK